### PR TITLE
Fix #46: Jakarta faces autocomplete doesn't work

### DIFF
--- a/src/parse-engines/common/parse-engine-registry.ts
+++ b/src/parse-engines/common/parse-engine-registry.ts
@@ -11,7 +11,7 @@ enum Configuration {
 }
 class ParseEngineRegistry {
     public static getParseEngine(taglibId: string): IParseEngine {
-        const foundParseEngine = ParseEngineRegistry.registry.find((value) => value.version === taglibId);
+        const foundParseEngine = ParseEngineRegistry.registry.find((value) => value.version.startsWith(taglibId));
         if (!foundParseEngine) {
             throw new Error(`Could not find a parse engine for the provided id ("${taglibId}").`);
         }


### PR DESCRIPTION
Fix #46: Jakarta faces autocomplete doesn't work

Two issues:

- [x] This === compare with version/taglibId won't match since it's comparing h with h-4.1; should probably be startsWith. (https://github.com/primefaces-extensions/faces-intellisense/blob/main/src/parse-engines/common/parse-engine-registry.ts#L14)
- [x] I think we need to look at the VDL parser; the JSON files aren't getting the component names correctly: https://github.com/primefaces-extensions/faces-intellisense/blob/main/src/parse-engines/data/jakarta/h-4.1.json